### PR TITLE
feat: add align argument to control horizontal diagram alignment

### DIFF
--- a/assets/scss/mermaid.scss
+++ b/assets/scss/mermaid.scss
@@ -34,7 +34,27 @@ pre.mermaid:not([data-processed]) {
 
 .diagram-wrapper > pre > svg {
     display: block;
-    margin: auto;    
+    margin: auto;
+}
+
+/* Horizontal alignment of the diagram (shortcode `align` argument). Only
+ * `center` and `end` emit a modifier class; `start` keeps the default flow. */
+.mermaid-align-center > svg,
+.mermaid-align-end > svg,
+.mermaid-align-center .diagram-wrapper > pre > svg,
+.mermaid-align-end .diagram-wrapper > pre > svg {
+    display: block;
+}
+
+.mermaid-align-center > svg,
+.mermaid-align-center .diagram-wrapper > pre > svg {
+    margin-inline: auto;
+}
+
+.mermaid-align-end > svg,
+.mermaid-align-end .diagram-wrapper > pre > svg {
+    margin-inline-start: auto;
+    margin-inline-end: 0;
 }
 
 [data-mermaid-theme="light"]{

--- a/data/structures/mermaid.yml
+++ b/data/structures/mermaid.yml
@@ -17,6 +17,11 @@ arguments:
     group: partial
   controls:
     release: v1.7.0
+  align:
+    comment: >-
+      Horizontal alignment of the rendered diagram. Only `center` and `end`
+      shift the diagram; `start` keeps the diagram's default flow.
+    release: v4.5.0
 body:
   optional: false
   comment: >-

--- a/layouts/_partials/assets/mermaid.html
+++ b/layouts/_partials/assets/mermaid.html
@@ -23,10 +23,16 @@
 {{- $diagramZoomOut := partial "utilities/GetThemeIcon.html" (dict "id" "diagramZoomOut" "default" "fas magnifying-glass-minus") -}}
 {{- $diagramZoomIn := partial "utilities/GetThemeIcon.html" (dict "id" "diagramZoomIn" "default" "fas magnifying-glass-plus") -}}
 
+{{/* Optional alignment modifier (center/end only; start keeps the default flow) */}}
+{{- $alignClass := "" -}}
+{{- if in (slice "center" "end") $args.align -}}
+    {{- $alignClass = printf " mermaid-align-%s" $args.align -}}
+{{- end -}}
+
 {{/* Main code */}}
 {{ if not $error }}
     {{ if $args.controls }}
-        <div class="diagram-container">
+        <div class="diagram-container{{ $alignClass }}">
             <div class="diagram-controls">
                 <button class="control-btn control-btn-expand">
                     {{- partial "assets/icon.html" (dict "icon" $diagramExpand "class" "fa-fw fa-xl" "spacing" false) -}}
@@ -44,6 +50,6 @@
             </div>
         </div>
      {{ else }}
-        <pre class="mermaid">{{ $args.raw | safeHTML }}</pre>
+        <pre class="mermaid{{ $alignClass }}">{{ $args.raw | safeHTML }}</pre>
      {{ end }}
 {{ end }}

--- a/layouts/_shortcodes/mermaid.html
+++ b/layouts/_shortcodes/mermaid.html
@@ -22,5 +22,5 @@
 
 {{/* Main code */}}
 {{ if not $error }}
-    {{ partial "assets/mermaid.html" (dict "page" .Page "raw" .Inner "controls" $args.controls) }}
+    {{ partial "assets/mermaid.html" (dict "page" .Page "raw" .Inner "controls" $args.controls "align" $args.align) }}
 {{ end }}


### PR DESCRIPTION
## Summary

Adds an optional `align` argument to the `mermaid` shortcode so a diagram can be aligned horizontally:

```text
{{< mermaid align="center" >}} … {{< /mermaid >}}
```

It reuses the shared `align` select argument (`start` | `center` | `end`, default `start`).

## Behavior

- `center` / `end` add a `mermaid-align-{value}` modifier class to the outer element (the `<pre class="mermaid">`, or the `.diagram-container` when `controls` is set); the new CSS centers / right-aligns the rendered `<svg>` via `margin-inline`.
- `start` is a **no-op** (emits no class), so every existing diagram — and the controls-mode auto-centering — renders exactly as before. Fully backward compatible.

## Changes

- `data/structures/mermaid.yml` — declare the `align` argument (`release: v4.5.0`).
- `layouts/_shortcodes/mermaid.html` — thread `align` through to the partial.
- `layouts/_partials/assets/mermaid.html` — emit the modifier class.
- `assets/scss/mermaid.scss` — alignment rules for `center` / `end`.

## Validation

- `npm test` (exampleSite build) passes via the pre-commit hook.
- Verified end-to-end in a downstream site: the diagram gains `class="mermaid mermaid-align-center"` and the compiled `mermaid.css` contains the `.mermaid-align-center > svg { margin-inline: auto }` rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
