### PR TITLE
fix: correct align argument release version to Hinode v2.12.0

### DIFF
--- a/data/structures/mermaid.yml
+++ b/data/structures/mermaid.yml
@@ -21,7 +21,7 @@ arguments:
     comment: >-
       Horizontal alignment of the rendered diagram. Only `center` and `end`
       shift the diagram; `start` keeps the diagram's default flow.
-    release: v4.5.0
+    release: v2.12.0
 body:
   optional: false
   comment: >-


### PR DESCRIPTION
## Summary

Follow-up to #319. The new `align` argument declared `release: v4.5.0` — the mod-mermaid module version. The `release` field tracks the **Hinode** version that first ships the argument (for reference, `controls` is `v1.7.0`), so this corrects it to **v2.12.0**, the next Hinode minor after the current v2.11.4.

Metadata only — no behavior or rendering change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
