### PR TITLE
feat: add opt-in fullscreen control to mermaid

### DIFF
--- a/assets/scss/mermaid.scss
+++ b/assets/scss/mermaid.scss
@@ -24,6 +24,22 @@ pre.mermaid:not([data-processed]) {
     right: 0;
 }
 
+.control-btn {
+    padding: 0.25rem 0.4rem;
+    line-height: 1;
+    color: var(--bs-body-color);
+    background-color: transparent;
+    border: 0;
+    cursor: pointer;
+    appearance: none;
+    opacity: 0.65;
+}
+
+.control-btn:hover,
+.control-btn:focus-visible {
+    opacity: 1;
+}
+
 .diagram-controls ~ .diagram-wrapper {
     margin-top: 40px;
 }

--- a/config.toml
+++ b/config.toml
@@ -19,6 +19,9 @@
     source = 'data'
     target = 'data'
   [[module.mounts]]
+    source = 'i18n'
+    target = 'i18n'
+  [[module.mounts]]
     source = 'layouts'
     target = 'layouts'
   [[module.mounts]]

--- a/config.toml
+++ b/config.toml
@@ -31,6 +31,7 @@
 
 # Icon defaults for mod-mermaid components
 [params.icons]
-  diagramExpand   = "fas expand"
-  diagramZoomOut  = "fas magnifying-glass-minus"
-  diagramZoomIn   = "fas magnifying-glass-plus"
+  diagramExpand     = "fas arrows-to-dot"
+  diagramFullscreen = "fas expand"
+  diagramZoomOut    = "fas magnifying-glass-minus"
+  diagramZoomIn     = "fas magnifying-glass-plus"

--- a/data/structures/mermaid.yml
+++ b/data/structures/mermaid.yml
@@ -17,6 +17,8 @@ arguments:
     group: partial
   controls:
     release: v1.7.0
+  fullscreen:
+    release: v4.6.0
   align:
     comment: >-
       Horizontal alignment of the rendered diagram. Only `center` and `end`

--- a/data/structures/mermaid.yml
+++ b/data/structures/mermaid.yml
@@ -18,6 +18,12 @@ arguments:
   controls:
     release: v1.7.0
   fullscreen:
+    type: bool
+    default: false
+    optional: true
+    comment: >-
+      Flag indicating if the diagram should include a fullscreen control that
+      opens it in the lightbox overlay.
     release: v4.6.0
   align:
     comment: >-

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,0 +1,8 @@
+- id: diagramFullscreen
+  translation: "View fullscreen"
+- id: diagramExpand
+  translation: "Reset view"
+- id: diagramZoomOut
+  translation: "Zoom out"
+- id: diagramZoomIn
+  translation: "Zoom in"

--- a/layouts/_partials/assets/mermaid.html
+++ b/layouts/_partials/assets/mermaid.html
@@ -42,6 +42,7 @@
                     {{- partial "assets/icon.html" (dict "icon" $diagramFullscreen "class" "fa-fw fa-xl" "spacing" false) -}}
                 </button>
                 {{ end }}
+                {{/* control-btn-expand resets the pan/zoom (label/icon say "reset"); the class + diagramExpand id are load-bearing — mermaid-panzoom.mjs binds reset to .control-btn-expand, so do not rename them. */}}
                 <button type="button" class="control-btn control-btn-expand" aria-label="{{ i18n "diagramExpand" }}">
                     {{- partial "assets/icon.html" (dict "icon" $diagramExpand "class" "fa-fw fa-xl" "spacing" false) -}}
                 </button>

--- a/layouts/_partials/assets/mermaid.html
+++ b/layouts/_partials/assets/mermaid.html
@@ -19,9 +19,10 @@
     {{- $error = $args.err -}}
 {{- end -}}
 
-{{- $diagramExpand := partial "utilities/GetThemeIcon.html" (dict "id" "diagramExpand" "default" "fas expand") -}}
+{{- $diagramExpand := partial "utilities/GetThemeIcon.html" (dict "id" "diagramExpand" "default" "fas arrows-to-dot") -}}
 {{- $diagramZoomOut := partial "utilities/GetThemeIcon.html" (dict "id" "diagramZoomOut" "default" "fas magnifying-glass-minus") -}}
 {{- $diagramZoomIn := partial "utilities/GetThemeIcon.html" (dict "id" "diagramZoomIn" "default" "fas magnifying-glass-plus") -}}
+{{- $diagramFullscreen := partial "utilities/GetThemeIcon.html" (dict "id" "diagramFullscreen" "default" "fas expand") -}}
 
 {{/* Optional alignment modifier (center/end only; start keeps the default flow) */}}
 {{- $alignClass := "" -}}
@@ -31,16 +32,23 @@
 
 {{/* Main code */}}
 {{ if not $error }}
-    {{ if $args.controls }}
+    {{ if or $args.controls $args.fullscreen }}
+        {{ if $args.fullscreen }}{{ partial "utilities/AddModule.html" (dict "page" $args.page "module" "lightbox") }}{{ end }}
         <div class="diagram-container{{ $alignClass }}">
             <div class="diagram-controls">
-                <button class="control-btn control-btn-expand">
+                {{ if $args.fullscreen }}
+                <button type="button" class="control-btn control-btn-fullscreen" data-lightbox-trigger
+                        data-lightbox-source-closest=".diagram-container" aria-label="{{ i18n "diagramFullscreen" }}">
+                    {{- partial "assets/icon.html" (dict "icon" $diagramFullscreen "class" "fa-fw fa-xl" "spacing" false) -}}
+                </button>
+                {{ end }}
+                <button type="button" class="control-btn control-btn-expand" aria-label="{{ i18n "diagramExpand" }}">
                     {{- partial "assets/icon.html" (dict "icon" $diagramExpand "class" "fa-fw fa-xl" "spacing" false) -}}
                 </button>
-                <button class="control-btn control-btn-zoom-out">
+                <button type="button" class="control-btn control-btn-zoom-out" aria-label="{{ i18n "diagramZoomOut" }}">
                     {{- partial "assets/icon.html" (dict "icon" $diagramZoomOut "class" "fa-fw fa-xl" "spacing" false) -}}
                 </button>
-                <button class="control-btn control-btn-zoom-in">
+                <button type="button" class="control-btn control-btn-zoom-in" aria-label="{{ i18n "diagramZoomIn" }}">
                     {{- partial "assets/icon.html" (dict "icon" $diagramZoomIn "class" "fa-fw fa-xl" "spacing" false) -}}
                 </button>
             </div>

--- a/layouts/_shortcodes/mermaid.html
+++ b/layouts/_shortcodes/mermaid.html
@@ -22,5 +22,5 @@
 
 {{/* Main code */}}
 {{ if not $error }}
-    {{ partial "assets/mermaid.html" (dict "page" .Page "raw" .Inner "controls" $args.controls "align" $args.align) }}
+    {{ partial "assets/mermaid.html" (dict "page" .Page "raw" .Inner "controls" $args.controls "align" $args.align "fullscreen" $args.fullscreen) }}
 {{ end }}


### PR DESCRIPTION
## Summary

Adds an opt-in `fullscreen` control to the mermaid shortcode, so detailed diagrams can be opened in a full-screen lightbox. First consumer of the Hinode-core lightbox primitive (gethinode/hinode#feat-lightbox-primitive).

- New `fullscreen` shortcode argument (bool). `{{< mermaid fullscreen=true >}}` renders the full control cluster with a 4th **fullscreen** button; `controls=true` alone keeps the legacy 3-button cluster (backward compatible).
- The fullscreen button carries the lightbox contract (`data-lightbox-trigger` + `data-lightbox-source-closest=".diagram-container"`) and registers the `lightbox` module dependency via `AddModule`. No new panzoom JS — the cloned diagram's pan/zoom re-attaches via the existing observer.
- **Icon disambiguation:** the reset control previously used a fullscreen-arrows glyph (misleading). That glyph now belongs to the new fullscreen button; reset uses `fas arrows-to-dot`. Adds `diagramFullscreen` icon default.
- **Accessibility:** all four control buttons gain `type="button"` and i18n `aria-label`s (the three legacy buttons were previously icon-only with no accessible name). New `i18n/en.yaml` (`diagramFullscreen`, `diagramExpand`, `diagramZoomOut`, `diagramZoomIn`) — plus the `i18n` module mount the explicit mounts required.

## Verification

Verified end-to-end in a consuming site: the fullscreen button opens the core lightbox, the rendered diagram SVG is cloned in, the nested trigger is stripped, pan/zoom works inside the dialog, and all aria-labels resolve. Degrades gracefully where the lightbox core isn't present (inert button).

Note: `control-btn-expand` / `diagramExpand` are kept as-is despite now meaning "reset" — the class is load-bearing (mermaid-panzoom.mjs binds reset to `.control-btn-expand`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
