### PR TITLE
fix(mermaid): forward all fence attributes to the partial

### DIFF
--- a/layouts/_markup/render-codeblock-mermaid.html
+++ b/layouts/_markup/render-codeblock-mermaid.html
@@ -1,1 +1,12 @@
-{{ partial "assets/mermaid.html" (dict "page" .Page "raw" .Inner "controls" .Attributes.controls) }}
+{{- /*
+    Forward every fence attribute to the mermaid partial, not just `controls`.
+
+    A fenced diagram can carry attributes via the info string, e.g.
+    ```mermaid {controls=true fullscreen=true align=center}
+    Previously only `controls` was passed through, so `fullscreen`, `align`,
+    and any future argument were silently dropped on the code-block path
+    (the shortcode path already supports them). Merging `.Attributes` keeps
+    parity with the shortcode; `page` and `raw` are set last so a stray
+    attribute of the same name can't clobber them.
+*/ -}}
+{{ partial "assets/mermaid.html" (merge .Attributes (dict "page" .Page "raw" .Inner)) }}


### PR DESCRIPTION
## Summary

The code-block render hook (`_markup/render-codeblock-mermaid.html`) forwarded only the `controls` attribute to `assets/mermaid.html`, so `fullscreen`, `align`, and any future argument set on a fenced diagram (e.g. `` ```mermaid {fullscreen=true align=center} ``) were silently dropped — even though the shortcode path already supports them.

Merge the whole `.Attributes` map into the partial args instead; `page` and `raw` are set last so a stray attribute of the same name cannot clobber them.

## Verification

Built the exampleSite with a `{controls=true align=center}` fence: the control cluster **and** the `mermaid-align-center` class both render (previously only `controls` came through). `fullscreen` forwarding is confirmed too — it now reaches the partial's lightbox `AddModule` call (which needs a full hinode consumer to render; the minimal exampleSite lacks that partial).
