### PR TITLE
feat(mermaid): frosted backdrop behind the diagram controls

### DIFF
--- a/assets/scss/mermaid.scss
+++ b/assets/scss/mermaid.scss
@@ -22,6 +22,18 @@ pre.mermaid:not([data-processed]) {
     position: absolute;
     z-index: 1;
     right: 0;
+
+    // Frosted background so the icon-only controls stay legible when they
+    // overlay diagram content, mirroring Hinode's translucent navbar
+    // (semi-transparent body background + backdrop blur). Applies inline and
+    // in the fullscreen dialog.
+    background-color: rgba(var(--bs-body-bg-rgb), 0.65);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    // This module's SCSS compiles standalone (no theme variables in scope),
+    // so consume the theme radius via Hinode's --theme-border-radius custom
+    // property, falling back to Bootstrap's radius when used outside Hinode.
+    border-radius: var(--theme-border-radius, var(--bs-border-radius));
 }
 
 .control-btn {


### PR DESCRIPTION
## Summary

The icon-only diagram controls were hard to see when they overlaid diagram content (e.g. dense ER diagrams). Give the control cluster a frosted background — a translucent body background plus a backdrop blur, mirroring Hinode's transparent navbar — so the icons stay legible. Applies both inline and in the fullscreen dialog.

Radius comes from Hinode's `--theme-border-radius` custom property (with a Bootstrap `--bs-border-radius` fallback for standalone use), since this module's SCSS compiles without theme variables in scope.

## Verification

Built a consuming portal: the control cluster renders a frosted background over diagram content and takes the theme's border radius, matching the lightbox close button, in both inline and dialog modes.

Pairs with gethinode/hinode exposing `--theme-border-radius`; falls back to the Bootstrap radius until that lands.
