### PR TITLE
feat(mermaid): passive inline preview with dialog pan/zoom + auto fullscreen mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,19 @@ YOUR DIAGRAM
 {{< /mermaid >}}
 </pre>
 
+### Interactive controls
+
+A diagram accepts two per-diagram arguments — as fenced code-block attributes or shortcode parameters:
+
+- `controls` (bool) — render inline pan/zoom controls.
+- `fullscreen` (`true` | `false` | `auto`) — render a button that opens the diagram in a fullscreen dialog. `auto` enables it only for diagrams whose source exceeds `mermaid.autoThreshold` significant lines. A per-diagram value overrides the site-wide `mermaid.fullscreen` default.
+
+```mermaid {fullscreen=true}
+YOUR DIAGRAM
+```
+
+When `fullscreen` is enabled, the inline diagram is a **passive preview**: the whole diagram is clickable to open the dialog, page scroll is never trapped, and all pan/zoom happen inside the dialog. When only `controls` is set (no dialog), inline pan/zoom stay active but **cooperative** — the wheel zooms only with `Ctrl`/`⌘` held (plain wheel scrolls the page), and touch pans with two fingers.
+
 The module supports dark mode and allows creation of a custom mermaid theme by overriding and setting the theme variables in `assets/scss/mermaid.scss`. Checkout the [mermaid docs](https://mermaid.js.org/config/theming.html) for custom styling. All theme variables can be used, but in kebab case and with prefix as shown in the example below. Also Bootstrap theme variables can be referenced.
 
 ```scss

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ This module supports the following parameters (see the section `params.modules` 
 | mermaid.elk    | false     | If set, installs the layout engine for Mermaid based on the ELK layout engine. |
 | mermaid.layout | `dagre`   | Defines which layout algorithm to use for rendering Mermaid diagrams. The default algorithm is `dagre`. Additional options are available when `mermaid.elk` is enabled, see the table below. |
 | mermaid.look   | `classic` | Defines the default look for Mermaid diagrams, either `classic` or `handDrawn`. |
+| mermaid.fullscreen | `false` | Site-wide default for the per-diagram `fullscreen` argument. `true`/`false` force the fullscreen affordance; `auto` enables it only for diagrams whose source exceeds `mermaid.autoThreshold` significant lines. A per-diagram value overrides this. |
+| mermaid.autoThreshold | `10` | Significant-line count above which `fullscreen: auto` enables the fullscreen affordance. |
 
 The following table defines the available layout algorithms. The `elk` values require installation of the ELK layout engine (set `mermaid.elk` to `true`).
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ YOUR DIAGRAM
 A diagram accepts two per-diagram arguments — as fenced code-block attributes or shortcode parameters:
 
 - `controls` (bool) — render inline pan/zoom controls.
-- `fullscreen` (`true` | `false` | `auto`) — render a button that opens the diagram in a fullscreen dialog. `auto` enables it only for diagrams whose source exceeds `mermaid.autoThreshold` significant lines. A per-diagram value overrides the site-wide `mermaid.fullscreen` default.
+- `fullscreen` (`true` | `false` | `auto`) — render a button that opens the diagram in a fullscreen dialog. `auto` enables it only for diagrams whose source has at least `mermaid.autoThreshold` significant lines beyond the diagram-type header. A per-diagram value overrides the site-wide `mermaid.fullscreen` default.
 
 ```mermaid {fullscreen=true}
 YOUR DIAGRAM
@@ -102,7 +102,7 @@ This module supports the following parameters (see the section `params.modules` 
 | mermaid.elk    | false     | If set, installs the layout engine for Mermaid based on the ELK layout engine. |
 | mermaid.layout | `dagre`   | Defines which layout algorithm to use for rendering Mermaid diagrams. The default algorithm is `dagre`. Additional options are available when `mermaid.elk` is enabled, see the table below. |
 | mermaid.look   | `classic` | Defines the default look for Mermaid diagrams, either `classic` or `handDrawn`. |
-| mermaid.fullscreen | `false` | Site-wide default for the per-diagram `fullscreen` argument. `true`/`false` force the fullscreen affordance; `auto` enables it only for diagrams whose source exceeds `mermaid.autoThreshold` significant lines. A per-diagram value overrides this. |
+| mermaid.fullscreen | `false` | Site-wide default for the per-diagram `fullscreen` argument. `true`/`false` force the fullscreen affordance; `auto` enables it only for diagrams whose source has at least `mermaid.autoThreshold` significant lines beyond the diagram-type header. A per-diagram value overrides this. |
 | mermaid.autoThreshold | `10` | Significant-line count above which `fullscreen: auto` enables the fullscreen affordance. |
 
 The following table defines the available layout algorithms. The `elk` values require installation of the ELK layout engine (set `mermaid.elk` to `true`).

--- a/assets/js/modules/mermaid/mermaid-panzoom.mjs
+++ b/assets/js/modules/mermaid/mermaid-panzoom.mjs
@@ -4,12 +4,13 @@ const step = 1.2
 const zoomFactor = 0.02
 
 let current, mouseX, mouseY, touchX, touchY
+let initialDistance, initialScale
 
 // Update transform
 function updateTransform(wrapper, translateX, translateY, scale, ease) {
     setScale(wrapper, scale)
 
-    if (ease) { 
+    if (ease) {
         wrapper.style.transition = 'all 0.3s ease-in-out'
     } else {
         wrapper.style.transition = ''
@@ -25,16 +26,16 @@ function getTranslateXY(element) {
         translateY: matrix.m42
     }
 }
+
 function getScale(wrapper) {
-    const scale = wrapper.getAttribute('data-scale') || 1
-    return scale
+    return wrapper.getAttribute('data-scale') || 1
 }
 
 function setScale(wrapper, scale) {
     wrapper.setAttribute('data-scale', scale)
 }
 
-// Zoom and expand functions
+// Zoom and reset helpers
 function expand(wrapper) {
     wrapper.style.transformOrigin = ''
     updateTransform(wrapper, 0, 0, 1, true)
@@ -50,16 +51,12 @@ function fit(wrapper) {
     const ww = wrapper.offsetWidth
     const wh = wrapper.offsetHeight
     if (!cw || !ch || !ww || !wh) { expand(wrapper); return }
-    // Inset the fit area so the diagram never sits flush against the edges,
-    // with extra room at the top for the controls cluster (top-right).
     const padX = 24
     const padTop = 48
     const padBottom = 24
     const availW = Math.max(1, cw - 2 * padX)
     const availH = Math.max(1, ch - padTop - padBottom)
     const scale = Math.min(availW / ww, availH / wh, minScale)
-    // Centre within the inset area, correcting for the wrapper's own layout
-    // offset (it carries a top margin that clears the controls).
     const left = padX + (availW - ww * scale) / 2
     const top = padTop + (availH - wh * scale) / 2
     wrapper.style.transformOrigin = '0 0'
@@ -81,31 +78,27 @@ function fitWhenReady(wrapper, tries = 0) {
 function zoomIn(wrapper) {
     const scale = Math.min(getScale(wrapper) * step, minScale)
     const c = getTranslateXY(wrapper)
-    // wrapper.style.transformOrigin = ''
     updateTransform(wrapper, c.translateX, c.translateY, scale, true)
 }
 
 function zoomOut(wrapper) {
     const scale = Math.max(getScale(wrapper) / step, maxScale)
     const c = getTranslateXY(wrapper)
-    // wrapper.style.transformOrigin = ''
     updateTransform(wrapper, c.translateX, c.translateY, scale, true)
 }
 
-// Event handlers
+// Mouse drag (pan) — bound only where gestures are active.
 function handleMousedown(wrapper, e) {
-        e.preventDefault()
-
-        wrapper.parentElement.classList.add('grabbing')
-        current = getTranslateXY(wrapper)
-        mouseX = e.clientX
-        mouseY = e.clientY
+    e.preventDefault()
+    wrapper.parentElement.classList.add('grabbing')
+    current = getTranslateXY(wrapper)
+    mouseX = e.clientX
+    mouseY = e.clientY
 }
 
 function handleMousemove(wrapper, e) {
     if (Array.from(wrapper.parentElement.classList).includes('grabbing')) {
         e.preventDefault()
-
         const deltaX = current.translateX + e.clientX - mouseX
         const deltaY = current.translateY + e.clientY - mouseY
         updateTransform(wrapper, deltaX, deltaY, getScale(wrapper))
@@ -114,96 +107,103 @@ function handleMousemove(wrapper, e) {
 
 function handleMouseup(wrapper, e) {
     e.preventDefault()
-
     wrapper.parentElement.classList.remove('grabbing')
     mouseX = null
     mouseY = null
     current = null
 }
 
-function handleWheel(wrapper, e) {
+// Wheel zoom. Gated by requireModifier so plain wheel scrolls the page inline;
+// the dialog is modal (nothing scrolls behind it) so it passes false.
+function handleWheel(wrapper, e, requireModifier) {
+    if (requireModifier && !(e.ctrlKey || e.metaKey)) return
     e.preventDefault()
-    
-    // Get mouse position relative to the container
+
     const rect = wrapper.parentElement.getBoundingClientRect()
     const clientX = e.clientX - rect.left
     const clientY = e.clientY - rect.top
     const currentScale = getScale(wrapper)
     const curr = getTranslateXY(wrapper)
 
-    // Calculate zoom direction and new scale
-    const zoomIn = e.deltaY < 0
-    const factor = zoomIn ? (1 + zoomFactor) : (1 - zoomFactor)
+    const zoomingIn = e.deltaY < 0
+    const factor = zoomingIn ? (1 + zoomFactor) : (1 - zoomFactor)
     const newScale = Math.max(maxScale, Math.min(minScale, currentScale * factor))
-    
+
     if (newScale !== currentScale) {
-        // Calculate the zoom factor that was actually applied
         const actualFactor = newScale / currentScale
-        
-        // Adjust translation to zoom towards mouse position
         const currentTranslateX = clientX - (clientX - curr.translateX) * actualFactor
         const currentTranslateY = clientY - (clientY - curr.translateY) * actualFactor
-        
         wrapper.style.transformOrigin = '0 0'
         updateTransform(wrapper, currentTranslateX, currentTranslateY, newScale)
     }
 }
 
-// Touch events for mobile
-function handleTouchstart(wrapper, e) {
+// Touch. oneFingerPan=false (INLINE-A) lets a single-finger drag scroll the
+// page; two fingers always pan/pinch.
+function handleTouchstart(wrapper, e, oneFingerPan) {
     if (e.touches.length === 1) {
+        if (!oneFingerPan) return
         touchX = e.touches[0].clientX
         touchY = e.touches[0].clientY
         wrapper.parentElement.classList.add('grabbing')
     } else if (e.touches.length === 2) {
         e.preventDefault()
         wrapper.parentElement.classList.remove('grabbing')
-        
-        const touch1 = e.touches[0]
-        const touch2 = e.touches[1]
-        
-        initialDistance = Math.sqrt(
-            Math.pow(touch2.clientX - touch1.clientX, 2) +
-            Math.pow(touch2.clientY - touch1.clientY, 2)
-        )
-        initialScale = scale
+        const t1 = e.touches[0]
+        const t2 = e.touches[1]
+        initialDistance = Math.hypot(t2.clientX - t1.clientX, t2.clientY - t1.clientY)
+        initialScale = Number(getScale(wrapper))
     }
 }
 
-function handleTouchmove(wrapper, e) {
+function handleTouchmove(wrapper, e, oneFingerPan) {
     if (e.touches.length === 1) {
+        if (!oneFingerPan) return
         if (!Array.from(wrapper.parentElement.classList).includes('grabbing')) return
         e.preventDefault()
-        
         const deltaX = e.touches[0].clientX - (touchX || 0)
         const deltaY = e.touches[0].clientY - (touchY || 0)
         const c = getTranslateXY(wrapper)
-
-        const translateX = c.translateX + deltaX
-        const translateY = c.translateY + deltaY
-                
         touchX = e.touches[0].clientX
         touchY = e.touches[0].clientY
-        
-        updateTransform(wrapper, translateX, translateY, getScale(wrapper))
+        updateTransform(wrapper, c.translateX + deltaX, c.translateY + deltaY, getScale(wrapper))
     } else if (e.touches.length === 2) {
         e.preventDefault()
-        const touch1 = e.touches[0]
-        const touch2 = e.touches[1]
+        const t1 = e.touches[0]
+        const t2 = e.touches[1]
         const c = getTranslateXY(wrapper)
-        
-        const currentDistance = Math.sqrt(
-            Math.pow(touch2.clientX - touch1.clientX, 2) +
-            Math.pow(touch2.clientY - touch1.clientY, 2)
-        );
-        
+        const currentDistance = Math.hypot(t2.clientX - t1.clientX, t2.clientY - t1.clientY)
         const scale = Math.max(maxScale, Math.min(minScale, initialScale * (currentDistance / initialDistance)))
-        updateTransform(wrapper, c.currentTranslateX, c.currentTranslateY, scale)
+        updateTransform(wrapper, c.translateX, c.translateY, scale)
     }
 }
 
-function handleTouchend(wrapper, e) {
+function handleTouchend(wrapper) {
     wrapper.parentElement.classList.remove('grabbing')
+}
+
+// Bind interactive gestures (drag + wheel + touch) to a wrapper's container.
+function bindGestures(wrapper, container, { requireModifier, oneFingerPan }) {
+    container.addEventListener('mousedown', (e) => handleMousedown(wrapper, e))
+    container.addEventListener('mousemove', (e) => handleMousemove(wrapper, e))
+    document.addEventListener('mouseup', (e) => handleMouseup(wrapper, e))
+    container.addEventListener('touchstart', (e) => handleTouchstart(wrapper, e, oneFingerPan))
+    container.addEventListener('touchmove', (e) => handleTouchmove(wrapper, e, oneFingerPan), { passive: false })
+    container.addEventListener('touchend', () => handleTouchend(wrapper))
+    container.addEventListener('wheel', (e) => handleWheel(wrapper, e, requireModifier), { passive: false })
+}
+
+// INLINE-B: passive preview with a fullscreen button. Clicking anywhere on the
+// diagram (except a control) opens the dialog by delegating to the accessible
+// fullscreen button — no extra data-lightbox-trigger on the container.
+function makeClickToOpen(container) {
+    const trigger = container.querySelector('.control-btn-fullscreen')
+    if (!trigger) return
+    container.classList.add('diagram-clickable')
+    container.addEventListener('click', (e) => {
+        if (e.target.closest('.control-btn')) return
+        trigger.click()
+    })
 }
 
 function initWrapper(wrapper) {
@@ -211,31 +211,30 @@ function initWrapper(wrapper) {
     wrapper.dataset.panzoomInit = 'true'
 
     const container = wrapper.parentElement
-
-    // In a dialog (the fullscreen lightbox) the intent is to see the whole
-    // diagram, so the reset control fits the entire bounding box and the
-    // diagram opens fitted. Inline keeps the width-fill behaviour, where a
-    // tall diagram stays reachable via the container's vertical scroll.
     const inDialog = !!wrapper.closest('dialog')
-    const reset = inDialog ? () => fit(wrapper) : () => expand(wrapper)
+    const hasFullscreen = !!container.querySelector('.control-btn-fullscreen')
 
+    // Reset control: fit the whole diagram in the dialog, else reset transform.
+    const reset = inDialog ? () => fit(wrapper) : () => expand(wrapper)
     const btnExpand = container.querySelector('.control-btn-expand')
     const btnZoomOut = container.querySelector('.control-btn-zoom-out')
     const btnZoomIn = container.querySelector('.control-btn-zoom-in')
-
     if (btnExpand) btnExpand.addEventListener('click', reset)
-    if (btnZoomOut) btnZoomOut.addEventListener('click', () => { zoomOut(wrapper) })
-    if (btnZoomIn) btnZoomIn.addEventListener('click', () => { zoomIn(wrapper) })
+    if (btnZoomOut) btnZoomOut.addEventListener('click', () => zoomOut(wrapper))
+    if (btnZoomIn) btnZoomIn.addEventListener('click', () => zoomIn(wrapper))
 
-    container.addEventListener('mousedown', (e) => { handleMousedown(wrapper, e) })
-    container.addEventListener('mousemove', (e) => { handleMousemove(wrapper, e) })
-    document.addEventListener('mouseup', (e) => { handleMouseup(wrapper, e) })
-    container.addEventListener('touchstart', (e) => { handleTouchstart(wrapper, e) })
-    container.addEventListener('touchmove', (e) => { handleTouchmove(wrapper, e) })
-    container.addEventListener('touchend', (e) => { handleTouchend(wrapper, e) })
-    container.addEventListener('wheel', (e) => { handleWheel(wrapper, e) })
-
-    if (inDialog) fitWhenReady(wrapper)
+    if (inDialog) {
+        // Modal: pan/zoom own the viewport, wheel needs no modifier.
+        bindGestures(wrapper, container, { requireModifier: false, oneFingerPan: true })
+        fitWhenReady(wrapper)
+    } else if (hasFullscreen) {
+        // INLINE-B: passive preview; the whole diagram opens the dialog.
+        makeClickToOpen(container)
+    } else {
+        // INLINE-A: no dialog to escape to — cooperative inline gestures.
+        container.classList.add('diagram-interactive')
+        bindGestures(wrapper, container, { requireModifier: true, oneFingerPan: false })
+    }
 }
 
 document.querySelectorAll('.diagram-wrapper').forEach(wrapper => initWrapper(wrapper))

--- a/assets/js/modules/mermaid/mermaid-panzoom.mjs
+++ b/assets/js/modules/mermaid/mermaid-panzoom.mjs
@@ -224,7 +224,10 @@ function initWrapper(wrapper) {
     if (btnZoomIn) btnZoomIn.addEventListener('click', () => zoomIn(wrapper))
 
     if (inDialog) {
-        // Modal: pan/zoom own the viewport, wheel needs no modifier.
+        // Modal: pan/zoom own the viewport, wheel needs no modifier. The clone
+        // inherits the inline preview's marker class from the source node; drop
+        // it so the dialog cursor is grab, not the inline zoom-in.
+        container.classList.remove('diagram-clickable', 'diagram-interactive')
         bindGestures(wrapper, container, { requireModifier: false, oneFingerPan: true })
         fitWhenReady(wrapper)
     } else if (hasFullscreen) {

--- a/assets/scss/mermaid.scss
+++ b/assets/scss/mermaid.scss
@@ -11,11 +11,43 @@ pre.mermaid:not([data-processed]) {
 .diagram-container {
     position: relative;
     overflow: hidden;
+    cursor: default;        // inline preview is passive by default
+    touch-action: auto;     // let the page scroll/pan over inline diagrams
+}
+
+// Inline diagrams that can be expanded to the dialog read as clickable.
+.diagram-container.diagram-clickable {
+    cursor: zoom-in;
+}
+
+// The fullscreen dialog: pan/zoom own the modal viewport.
+dialog .diagram-container {
     cursor: grab;
+    touch-action: none;
+}
+
+// INLINE-A (controls without a dialog): cooperative inline pan/zoom. Drag pans;
+// one-finger vertical scroll must still reach the page, so allow pan-y.
+.diagram-container.diagram-interactive {
+    cursor: grab;
+    touch-action: pan-y;
 }
 
 .diagram-container.grabbing {
     cursor: grabbing;
+}
+
+// Hide the reset/zoom controls on the inline preview (only the fullscreen
+// button shows); the dialog clone re-shows them.
+.diagram-has-fullscreen {
+    .control-btn-expand,
+    .control-btn-zoom-out,
+    .control-btn-zoom-in { display: none; }
+}
+dialog .diagram-has-fullscreen {
+    .control-btn-expand,
+    .control-btn-zoom-out,
+    .control-btn-zoom-in { display: inline-flex; }
 }
 
 .diagram-controls {

--- a/data/structures/mermaid.yml
+++ b/data/structures/mermaid.yml
@@ -18,12 +18,20 @@ arguments:
   controls:
     release: v1.7.0
   fullscreen:
-    type: bool
+    type: string
     default: false
+    config: modules.mermaid.fullscreen
     optional: true
+    options:
+      values:
+        - "true"
+        - "false"
+        - "auto"
     comment: >-
-      Flag indicating if the diagram should include a fullscreen control that
-      opens it in the lightbox overlay.
+      Controls the fullscreen affordance. "true"/"false" force it on/off;
+      "auto" enables it only for diagrams whose source exceeds
+      `modules.mermaid.autoThreshold` significant lines. When unset, falls back
+      to the site parameter `modules.mermaid.fullscreen`, then to false.
     release: v4.6.0
   align:
     comment: >-

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -6,6 +6,8 @@
         elk = true
         layout = "elk"
         look = "classic"
+        fullscreen = "auto"
+        autoThreshold = 10
 
 [debugging]
     showJS = true

--- a/exampleSite/content/resolution.md
+++ b/exampleSite/content/resolution.md
@@ -1,0 +1,74 @@
+---
+title: Resolution tests
+modules: ["mermaid"]
+---
+
+## 1. Explicit true, simple → ON
+
+```mermaid {fullscreen=true}
+flowchart TD
+  A --> B
+  B --> C
+```
+
+## 2. Explicit auto, dense → ON
+
+```mermaid {fullscreen=auto}
+flowchart TD
+  A --> B
+  B --> C
+  C --> D
+  D --> E
+  E --> F
+  F --> G
+  G --> H
+  H --> I
+  I --> J
+  J --> K
+  K --> L
+  L --> M
+```
+
+## 3. Site-default auto, dense → ON
+
+```mermaid
+flowchart TD
+  A --> B
+  B --> C
+  C --> D
+  D --> E
+  E --> F
+  F --> G
+  G --> H
+  H --> I
+  I --> J
+  J --> K
+  K --> L
+  L --> M
+```
+
+## 4. Site-default auto, simple → OFF
+
+```mermaid
+flowchart TD
+  A --> B
+  B --> C
+```
+
+## 5. Explicit false, dense → OFF
+
+```mermaid {fullscreen=false}
+flowchart TD
+  A --> B
+  B --> C
+  C --> D
+  D --> E
+  E --> F
+  F --> G
+  G --> H
+  H --> I
+  I --> J
+  J --> K
+  K --> L
+  L --> M
+```

--- a/exampleSite/layouts/_partials/utilities/AddModule.html
+++ b/exampleSite/layouts/_partials/utilities/AddModule.html
@@ -1,0 +1,6 @@
+{{- /*
+    No-op stub of hinode's `utilities/AddModule.html`. The module exampleSite
+    is hinode-free (its workspace is `use .` + `use ../`), so this stub lets it
+    build `fullscreen`-enabled diagrams — the real hinode partial registers the
+    lightbox module for loading; here we only need the mermaid markup to render.
+*/ -}}

--- a/layouts/_partials/assets/mermaid.html
+++ b/layouts/_partials/assets/mermaid.html
@@ -25,7 +25,8 @@
      NEVER use `| default` on it — that would clobber an explicit false. */}}
 {{- $fs := false -}}
 {{- if eq (lower (string $args.fullscreen)) "auto" -}}
-    {{- $threshold := int (or (index site.Params "modules" "mermaid" "autoThreshold") 10) -}}
+    {{- $atRaw := index site.Params "modules" "mermaid" "autoThreshold" -}}
+    {{- $threshold := int (cond (eq $atRaw nil) 10 $atRaw) -}}
     {{- $score := 0 -}}
     {{- range (split (trim $args.raw "\r\n") "\n") -}}
         {{- $line := trim . " \t\r" -}}

--- a/layouts/_partials/assets/mermaid.html
+++ b/layouts/_partials/assets/mermaid.html
@@ -1,4 +1,4 @@
-{{/* 
+{{/*
     Copyright © 2025 The Hinode Team / Mark Dumay. All rights reserved.
     Use of this source code is governed by The MIT License (MIT) that can be found in the LICENSE file.
     Visit gethinode.com/license for more details.
@@ -9,14 +9,34 @@
 {{/* Initialize arguments */}}
 {{- $args := partial "utilities/InitArgs.html" (dict "structure" "mermaid" "args" . "group" "partial") -}}
 {{- if or $args.err $args.warnmsg -}}
-    {{- partial (cond $args.err "utilities/LogErr.html" "utilities/LogWarn.html") (dict 
-        "partial" "assets/mermaid.html" 
+    {{- partial (cond $args.err "utilities/LogErr.html" "utilities/LogWarn.html") (dict
+        "partial" "assets/mermaid.html"
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
         "file"    page.File
     ) -}}
     {{- $error = $args.err -}}
+{{- end -}}
+
+{{/* Resolve the effective fullscreen boolean. InitArgs has already applied the
+     precedence (per-diagram value → site param modules.mermaid.fullscreen →
+     default false) into $args.fullscreen; here we only interpret the token.
+     NEVER use `| default` on it — that would clobber an explicit false. */}}
+{{- $fs := false -}}
+{{- if eq (lower (string $args.fullscreen)) "auto" -}}
+    {{- $threshold := int (or (index site.Params "modules" "mermaid" "autoThreshold") 10) -}}
+    {{- $score := 0 -}}
+    {{- range (split (trim $args.raw "\r\n") "\n") -}}
+        {{- $line := trim . " \t\r" -}}
+        {{- if and (ne $line "") (not (hasPrefix $line "%%")) -}}
+            {{- $score = add $score 1 -}}
+        {{- end -}}
+    {{- end -}}
+    {{/* The first significant line is the diagram-type header; don't count it. */}}
+    {{- $fs = ge (sub $score 1) $threshold -}}
+{{- else if $args.fullscreen -}}
+    {{- $fs = partial "utilities/CastBool.html" $args.fullscreen -}}
 {{- end -}}
 
 {{- $diagramExpand := partial "utilities/GetThemeIcon.html" (dict "id" "diagramExpand" "default" "fas arrows-to-dot") -}}
@@ -32,11 +52,11 @@
 
 {{/* Main code */}}
 {{ if not $error }}
-    {{ if or $args.controls $args.fullscreen }}
-        {{ if $args.fullscreen }}{{ partial "utilities/AddModule.html" (dict "page" $args.page "module" "lightbox") }}{{ end }}
-        <div class="diagram-container{{ $alignClass }}">
+    {{ if or $args.controls $fs }}
+        {{ if $fs }}{{ partial "utilities/AddModule.html" (dict "page" $args.page "module" "lightbox") }}{{ end }}
+        <div class="diagram-container{{ if $fs }} diagram-has-fullscreen{{ end }}{{ $alignClass }}">
             <div class="diagram-controls">
-                {{ if $args.fullscreen }}
+                {{ if $fs }}
                 <button type="button" class="control-btn control-btn-fullscreen" data-lightbox-trigger
                         data-lightbox-source-closest=".diagram-container" aria-label="{{ i18n "diagramFullscreen" }}">
                     {{- partial "assets/icon.html" (dict "icon" $diagramFullscreen "class" "fa-fw fa-xl" "spacing" false) -}}


### PR DESCRIPTION
## Why

Inline interactive diagrams bind the mouse **wheel** to zoom and drag to pan, so scrolling the page with the pointer over a diagram gets swallowed (the page "sticks") — the classic embedded-map scroll-trap. This makes the inline diagram a **passive preview** and moves all pan/zoom into the existing fullscreen dialog, following the cooperative-gesture pattern used by embedded maps.

## What changed

**Runtime (`mermaid-panzoom.mjs`, `mermaid.scss`)** — `initWrapper` now branches on `wrapper.closest('dialog')` and the presence of a fullscreen button:

- **Dialog** — full pan/zoom (wheel un-gated; it's modal, nothing scrolls behind it).
- **Inline + fullscreen (INLINE-B)** — passive: zero gesture listeners (no scroll-trap), the whole diagram is click-to-open (delegates to the accessible fullscreen button), only the fullscreen control shows.
- **Inline, controls-only (INLINE-A)** — cooperative: wheel zooms only with `Ctrl`/`⌘` (plain wheel scrolls the page), touch pans with two fingers.
- Repairs the previously-broken two-finger **pinch** (undefined state + wrong translate field — it threw in strict mode).

**Build-time (`data/structures/mermaid.yml`, `assets/mermaid.html`)** — `fullscreen` becomes tri-state `true | false | auto`. Precedence (per-diagram → site param `modules.mermaid.fullscreen` → default `false`) is owned by `InitArgs`'s `config`/`default` (consulted only when the arg is `nil`, so an explicit `false` is never clobbered). `auto` enables fullscreen when the diagram source has at least `modules.mermaid.autoThreshold` significant lines beyond the type header (default 10).

## Backward compatibility

Non-breaking. Defaults stay `controls=false` / `fullscreen=false`; existing `fullscreen=true/false` call sites are unaffected. `auto` is opt-in via one site-config line.

## Verification

- Build passes; rendered-HTML assertions confirm the resolution matrix (explicit true / explicit auto / site-auto-dense → on; site-auto-simple / explicit false → off).
- Behavior verified in the module exampleSite (plain wheel scrolls, `Ctrl`+wheel zooms, correct branch classes) and in a hinode host: click → dialog opens → clone re-inits → drag-pan + wheel-zoom work, `grab` cursor.

The exampleSite gains a no-op `AddModule` stub (exampleSite-only) so it can build fullscreen fixtures without importing hinode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)