### PR TITLE
fix(mermaid): prevent dialog fit-on-open jump

### DIFF
--- a/assets/js/modules/mermaid/mermaid-panzoom.mjs
+++ b/assets/js/modules/mermaid/mermaid-panzoom.mjs
@@ -44,7 +44,7 @@ function expand(wrapper) {
 // Fit the whole diagram (contain) within its container and centre it. Used in
 // fullscreen/dialog mode, where the intent is to see the entire bounding box
 // rather than fill the width and scroll vertically.
-function fit(wrapper) {
+function fit(wrapper, ease = true) {
     const container = wrapper.parentElement
     const cw = container.clientWidth
     const ch = container.clientHeight
@@ -60,18 +60,24 @@ function fit(wrapper) {
     const left = padX + (availW - ww * scale) / 2
     const top = padTop + (availH - wh * scale) / 2
     wrapper.style.transformOrigin = '0 0'
-    updateTransform(wrapper, left - wrapper.offsetLeft, top - wrapper.offsetTop, scale, true)
+    updateTransform(wrapper, left - wrapper.offsetLeft, top - wrapper.offsetTop, scale, ease)
 }
 
 // A dialog is laid out asynchronously after showModal(), so its container has
 // no size yet when the clone is first observed. Poll a few frames until it
-// does, then fit once.
+// does, then fit once — instantly (no eased transition) and only then reveal
+// the wrapper, so the diagram appears already settled instead of animating
+// into place from its unfitted clone position.
 function fitWhenReady(wrapper, tries = 0) {
     const container = wrapper.parentElement
     if (container.clientWidth > 0 && container.clientHeight > 0) {
-        fit(wrapper)
+        fit(wrapper, false)
+        wrapper.style.visibility = ''
     } else if (tries < 30) {
         requestAnimationFrame(() => fitWhenReady(wrapper, tries + 1))
+    } else {
+        // Sizing never resolved; reveal anyway so the diagram is never left hidden.
+        wrapper.style.visibility = ''
     }
 }
 
@@ -228,6 +234,9 @@ function initWrapper(wrapper) {
         // inherits the inline preview's marker class from the source node; drop
         // it so the dialog cursor is grab, not the inline zoom-in.
         container.classList.remove('diagram-clickable', 'diagram-interactive')
+        // Hide until the fit-on-open settles (revealed in fitWhenReady) so the
+        // dialog never shows the unfitted clone or a recenter/resize jump.
+        wrapper.style.visibility = 'hidden'
         bindGestures(wrapper, container, { requireModifier: false, oneFingerPan: true })
         fitWhenReady(wrapper)
     } else if (hasFullscreen) {


### PR DESCRIPTION
## Problem

Opening a diagram in the fullscreen dialog produced a visible **jump**: the diagram appeared at its unfitted clone position (natural size, top-left) and then animated (0.3s ease) to the fitted, centered position — a recenter/resize the reader sees.

## Fix

Render the diagram only once it has settled:

- Hide the dialog wrapper (`visibility: hidden`) on clone init.
- Apply the fit-on-open **instantly** (no eased transition) via a new `fit(wrapper, ease = false)` for the initial fit.
- Reveal the wrapper only after that fit lands.
- A fallback reveal guarantees the diagram is never left hidden if the dialog never reports a size.

The **Reset** control keeps its eased animation (it passes the default `ease = true`). Inline behavior is untouched.

## Verification

Root-caused to `fit()`'s `updateTransform(..., true)` ease on open. Verified in an isolated browser harness driving the real module: the wrapper's visibility transitions `hidden → ''`, and the fit lands with `transition: ''` (instant, not `0.3s`) at the correct fitted scale. exampleSite build clean; JS syntax checked.

Follow-up to #338 (v4.9.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)