### PR TITLE
fix: thread the owning page into diagram-control icon calls (render-once D8)

### DIFF
--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -3,8 +3,8 @@ module github.com/gethinode/mod-mermaid/exampleSite
 go 1.19
 
 require (
-	github.com/FortAwesome/Font-Awesome v0.0.0-20260625220317-70fb2dd154b6 // indirect
-	github.com/gethinode/mod-fontawesome/v6 v6.0.2 // indirect
+	github.com/FortAwesome/Font-Awesome v0.0.0-20260715180930-14c65a3747d0 // indirect
+	github.com/gethinode/mod-fontawesome/v6 v6.1.1 // indirect
 	github.com/gethinode/mod-mermaid/v5 v5.0.1 // indirect
 	github.com/gethinode/mod-utils/v6 v6.5.1 // indirect
 )

--- a/exampleSite/go.sum
+++ b/exampleSite/go.sum
@@ -2,6 +2,8 @@ github.com/FortAwesome/Font-Awesome v0.0.0-20260210181720-337dd2045d56 h1:wZEHFC
 github.com/FortAwesome/Font-Awesome v0.0.0-20260210181720-337dd2045d56/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/FortAwesome/Font-Awesome v0.0.0-20260625220317-70fb2dd154b6 h1:slcJCZg0UQMHqw5JCoVmE8/IJfoNUprTmP2T3lDG9VY=
 github.com/FortAwesome/Font-Awesome v0.0.0-20260625220317-70fb2dd154b6/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20260715180930-14c65a3747d0 h1:4+bB2ojsMTsQroHtQr1FWy2gxFzpBn5hISldeRfxF+o=
+github.com/FortAwesome/Font-Awesome v0.0.0-20260715180930-14c65a3747d0/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/airbnb/lottie-web v5.12.2+incompatible h1:Ldogtlhiucf7mMsgisyxSBY0qunV44+lpa9Icy2KoQc=
 github.com/airbnb/lottie-web v5.12.2+incompatible/go.mod h1:nTss557UK9FGnp8QYlCMO29tjUHwbdAHG/DprbGfHGE=
 github.com/gethinode/hinode v0.23.21 h1:tnjfA33d6WfwIXWxKZDcrg70+ftLJ+asCwYkWtyuKxo=
@@ -142,6 +144,8 @@ github.com/gethinode/mod-fontawesome/v6 v6.0.1 h1:Wq51kwbtlZYjLQdSbLjn1Qjf4ZkmGI
 github.com/gethinode/mod-fontawesome/v6 v6.0.1/go.mod h1:Pz24mpGcg4FvGHhwPiuEZzOzISeOcoaQROhI6xLW2bU=
 github.com/gethinode/mod-fontawesome/v6 v6.0.2 h1:MxaHU7MZIh4pgxtoR6C/F0qiB5eSiySmRpTw9DGIOVs=
 github.com/gethinode/mod-fontawesome/v6 v6.0.2/go.mod h1:Zy+hjVhFDU52nkTIn9btbZ1PWy2n203zKHiPG9RVSL0=
+github.com/gethinode/mod-fontawesome/v6 v6.1.1 h1:k5Jy7nA+YfLZ9YqXH8hyaiw9wjAeOxNEUcnu6fynnJo=
+github.com/gethinode/mod-fontawesome/v6 v6.1.1/go.mod h1:875OBk5te+KBJmr0PdSkFcduYnsKCuHWfcaqChh9NGo=
 github.com/gethinode/mod-google-analytics v1.1.4 h1:GkLzbSdVIMLWSQ4VOSaJZIKyofmVCzueiuiGc29jQOM=
 github.com/gethinode/mod-google-analytics v1.1.4/go.mod h1:dl628cFozpCvoIMCiV7ujzQipjxcm3eatXrSfLPWNII=
 github.com/gethinode/mod-google-analytics v1.1.5 h1:wlOcgwNEJAnIQmPJIo3cT06xnr1dxN/ydUIztoC/7rM=

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gethinode/mod-mermaid/v5
 go 1.19
 
 require (
-	github.com/FortAwesome/Font-Awesome v0.0.0-20260625220317-70fb2dd154b6 // indirect
-	github.com/gethinode/mod-fontawesome/v6 v6.0.2 // indirect
+	github.com/FortAwesome/Font-Awesome v0.0.0-20260715180930-14c65a3747d0 // indirect
+	github.com/gethinode/mod-fontawesome/v6 v6.1.1 // indirect
 	github.com/gethinode/mod-utils/v6 v6.5.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,15 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20260625220317-70fb2dd154b6 h1:slcJCZg0UQMHqw5JCoVmE8/IJfoNUprTmP2T3lDG9VY=
 github.com/FortAwesome/Font-Awesome v0.0.0-20260625220317-70fb2dd154b6/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20260715180930-14c65a3747d0 h1:4+bB2ojsMTsQroHtQr1FWy2gxFzpBn5hISldeRfxF+o=
+github.com/FortAwesome/Font-Awesome v0.0.0-20260715180930-14c65a3747d0/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/gethinode/mod-fontawesome/v6 v6.0.0 h1:PrfiMfVEAM5Lpnkp+sXOtOdRSOe3l56z+ngrPcACzlA=
 github.com/gethinode/mod-fontawesome/v6 v6.0.0/go.mod h1:ayMslv2xpC5cjxUVTkIlFBbOd1LM5ezIr0OSOr6q8Gk=
 github.com/gethinode/mod-fontawesome/v6 v6.0.1 h1:Wq51kwbtlZYjLQdSbLjn1Qjf4ZkmGIbYrwxlO2vt9Q8=
 github.com/gethinode/mod-fontawesome/v6 v6.0.1/go.mod h1:Pz24mpGcg4FvGHhwPiuEZzOzISeOcoaQROhI6xLW2bU=
 github.com/gethinode/mod-fontawesome/v6 v6.0.2 h1:MxaHU7MZIh4pgxtoR6C/F0qiB5eSiySmRpTw9DGIOVs=
 github.com/gethinode/mod-fontawesome/v6 v6.0.2/go.mod h1:Zy+hjVhFDU52nkTIn9btbZ1PWy2n203zKHiPG9RVSL0=
+github.com/gethinode/mod-fontawesome/v6 v6.1.1 h1:k5Jy7nA+YfLZ9YqXH8hyaiw9wjAeOxNEUcnu6fynnJo=
+github.com/gethinode/mod-fontawesome/v6 v6.1.1/go.mod h1:875OBk5te+KBJmr0PdSkFcduYnsKCuHWfcaqChh9NGo=
 github.com/gethinode/mod-utils/v6 v6.0.1 h1:EnmMHjqnI/xyHPXFj1SdRLfVxNunJcKLGVtSAAFTQ8w=
 github.com/gethinode/mod-utils/v6 v6.0.1/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=
 github.com/gethinode/mod-utils/v6 v6.4.0 h1:l49KrawKE/7c6XE00wXQ9T5/kuTfiETerBz6OWn3SJc=

--- a/layouts/_partials/assets/mermaid.html
+++ b/layouts/_partials/assets/mermaid.html
@@ -61,18 +61,18 @@
                 {{ if $fs }}
                 <button type="button" class="control-btn control-btn-fullscreen" data-lightbox-trigger
                         data-lightbox-source-closest=".diagram-container" aria-label="{{ i18n "diagramFullscreen" }}">
-                    {{- partial "assets/icon.html" (dict "icon" $diagramFullscreen "class" "fa-fw fa-xl" "spacing" false) -}}
+                    {{- partial "assets/icon.html" (dict "icon" $diagramFullscreen "class" "fa-fw fa-xl" "spacing" false "page" $args.page) -}}
                 </button>
                 {{ end }}
                 {{/* control-btn-expand resets the pan/zoom (label/icon say "reset"); the class + diagramExpand id are load-bearing — mermaid-panzoom.mjs binds reset to .control-btn-expand, so do not rename them. */}}
                 <button type="button" class="control-btn control-btn-expand" aria-label="{{ i18n "diagramExpand" }}">
-                    {{- partial "assets/icon.html" (dict "icon" $diagramExpand "class" "fa-fw fa-xl" "spacing" false) -}}
+                    {{- partial "assets/icon.html" (dict "icon" $diagramExpand "class" "fa-fw fa-xl" "spacing" false "page" $args.page) -}}
                 </button>
                 <button type="button" class="control-btn control-btn-zoom-out" aria-label="{{ i18n "diagramZoomOut" }}">
-                    {{- partial "assets/icon.html" (dict "icon" $diagramZoomOut "class" "fa-fw fa-xl" "spacing" false) -}}
+                    {{- partial "assets/icon.html" (dict "icon" $diagramZoomOut "class" "fa-fw fa-xl" "spacing" false "page" $args.page) -}}
                 </button>
                 <button type="button" class="control-btn control-btn-zoom-in" aria-label="{{ i18n "diagramZoomIn" }}">
-                    {{- partial "assets/icon.html" (dict "icon" $diagramZoomIn "class" "fa-fw fa-xl" "spacing" false) -}}
+                    {{- partial "assets/icon.html" (dict "icon" $diagramZoomIn "class" "fa-fw fa-xl" "spacing" false "page" $args.page) -}}
                 </button>
             </div>
 


### PR DESCRIPTION
## Render-once program — flip unblock, mod-mermaid side

The 4 diagram-control icons (fullscreen/expand/zoom-in/zoom-out) now pass `$args.page` into
`assets/icon.html` — under foreign-context `.Content` renders the ambient fallback registers
sprite symbols on the wrong page (4 of the flip gate's 13 dangling refs). Both entry points
(shortcode + codeblock render hook) bind `.Page`; `page` is a required structure arg.

go.mod floors mod-fontawesome at **v6.1.1** (released schema accepting the `page` arg).

**Gate** (hinode exampleSite @ 50b5612b): 0 ERROR, 98/26/24, WARN parity; only the 3 known
racy RSS files in any comparison; sprite audit clean. Suite green. Independently reviewed by
the program driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)