### PR TITLE
fix: register the mermaid module when a diagram renders

### DIFF
--- a/layouts/_partials/assets/mermaid.html
+++ b/layouts/_partials/assets/mermaid.html
@@ -54,6 +54,10 @@
 
 {{/* Main code */}}
 {{ if not $error }}
+    {{/* Register the mermaid module as a page dependency, so the page's script and stylesheet
+         handlers include its assets without requiring `modules = ["mermaid"]` in front matter.
+         Both entry points (codeblock render hook and shortcode) funnel through this partial. */}}
+    {{ partial "utilities/AddModule.html" (dict "page" $args.page "module" "mermaid") }}
     {{ if or $args.controls $fs }}
         {{ if $fs }}{{ partial "utilities/AddModule.html" (dict "page" $args.page "module" "lightbox") }}{{ end }}
         <div class="diagram-container{{ if $fs }} diagram-has-fullscreen{{ end }}{{ $alignClass }}">


### PR DESCRIPTION
Both entry points (codeblock render hook and shortcode) funnel through `assets/mermaid.html`, which rendered diagram markup without registering the mermaid module — the per-page `.mjs` glue bundle and stylesheet were missing unless the page set front-matter `modules = ["mermaid"]`. The partial now self-registers via `utilities/AddModule.html`; the existing lightbox registration is untouched.

Evidence (js-pipeline program J5): bare codeblock AND bare shortcode pages vs front-matter control on a hinode v3.6.2 exampleSite — after the fix all bare pages carry the `.mjs` script + stylesheet tags byte-identical to the control; the static-mounted mermaid library itself was never page-gated and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)